### PR TITLE
Replace `smart_str` by `smart_bytes` in order to be compatible with python 3

### DIFF
--- a/auth_remember/auth_utils.py
+++ b/auth_remember/auth_utils.py
@@ -1,6 +1,6 @@
 """Taken from django-dev (should be standard in django 1.4)"""
 import hashlib
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_bytes
 from django.utils.crypto import constant_time_compare
 
 UNUSABLE_PASSWORD = '!' # This will never be a valid hash
@@ -10,7 +10,7 @@ def get_hexdigest(algorithm, salt, raw_password):
     Returns a string of the hexdigest of the given plaintext password and salt
     using the given algorithm ('md5', 'sha1' or 'crypt').
     """
-    raw_password, salt = smart_str(raw_password), smart_str(salt)
+    raw_password, salt = smart_bytes(raw_password), smart_bytes(salt)
     if algorithm == 'crypt':
         try:
             import crypt

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ with open('README.rst', 'r') as fh:
 
 setup(
     name='django-auth-remember',
-    version='0.5',
+    version='0.6',
     url='https://github.com/ailabs/django-auth-remember/',
     license='MIT',
     author='Michael van Tellingen',


### PR DESCRIPTION
The `raw_password` and `salt` variables have to be bytes-strings, this is need for the `hashlib` methods.
For now the code works in python 2 but not in python 3, the current `smart_str` function does not convert the python 3 unicode string into bytes-string.
With the `smart_bytes` function, it works for both python 2 and 3.

I bumped the version number to `0.6` so for now we can keep using the current `0.5` version and only use the new one in chuck's python 3 branches.