### PR TITLE
Django 3 compatibility

### DIFF
--- a/auth_remember/models.py
+++ b/auth_remember/models.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from tkinter import CASCADE
 
 from django.db import models
 from django.contrib.auth.models import User

--- a/auth_remember/models.py
+++ b/auth_remember/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from tkinter import CASCADE
 
 from django.db import models
 from django.contrib.auth.models import User
@@ -34,6 +35,10 @@ class RememberToken(models.Model):
 
     created_initial = models.DateTimeField(editable=False, blank=False)
 
-    user = models.ForeignKey(User, related_name="remember_me_tokens")
+    user = models.ForeignKey(
+        User,
+        related_name="remember_me_tokens",
+        on_delete=models.CASCADE
+    )
 
     objects = RememberTokenManager()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ with open('README.rst', 'r') as fh:
 
 setup(
     name='django-auth-remember',
-    version='0.6',
+    version='0.7',
     url='https://github.com/ailabs/django-auth-remember/',
     license='MIT',
     author='Michael van Tellingen',


### PR DESCRIPTION
The current version of this package fails under Django 3 because the `ForeignKey` need to have the `on_delete` argument.
Here I just added this missing argument to the default one (should not change anything to the database) and bumped the version number.