### PR TITLE
Remove unused imports

### DIFF
--- a/auth_remember/utils.py
+++ b/auth_remember/utils.py
@@ -1,9 +1,7 @@
-import time
 import uuid
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.utils.http import cookie_date
 
 from auth_remember.auth_utils import make_password
 from auth_remember.models import RememberToken


### PR DESCRIPTION
`from django.utils.http import cookie_date` does not exist in Django 3 and it was unused, so I removed this import.